### PR TITLE
Feat: Manual build all

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -77,6 +77,6 @@ jobs:
       - name: 📤 Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.inputs.architecture }}
-          path: target/libseda_tally_vm*.a
+          name: ${{ github.event.inputs.architecture }}-debug-${{ github.event.inputs.debug }}
+          path: target/libseda_tally_vm*.*
           overwrite: true

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -74,10 +74,14 @@ jobs:
         if:  ${{ github.event.inputs.debug == 'false' }}
         run: |
           cargo xtask compile ${{ github.event.inputs.architecture }}
+
+      - name: 📝 Set Branch Name
+        id: set_branch
+        run:  echo "FORMATTED_REF=${{ github.ref }}" | sed 's/\//-/g' >> $GITHUB_OUTPUT
       
       - name: 📤 Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: branch-${{ github.ref }}arch-${{ github.event.inputs.architecture }}-debug-${{ github.event.inputs.debug }}
+          name: branch-${{ steps.set_branch.outputs.FORMATTED_REF }}-arch-${{ github.event.inputs.architecture }}-debug-${{ github.event.inputs.debug }}
           path: target/libseda_tally_vm*.*
           overwrite: true

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: 📥 Install Dependencies
         run: |
-          cargo xtask ci-install ${{ github.event.inputs.architecture }}
+          cargo xtask apt-install ${{ github.event.inputs.architecture }}
 
       - name: 🔨 Build Debug Library For ${{ github.event.inputs.architecture }}
         if: ${{ github.event.inputs.debug }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -10,6 +10,7 @@ on:
         description: 'The architecture to build for'
         type: choice
         options:
+          - all
           - aarch64
           - x86-64
           - static-aarch64
@@ -77,6 +78,6 @@ jobs:
       - name: 📤 Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.inputs.architecture }}-debug-${{ github.event.inputs.debug }}
+          name: branch-${{ github.ref }}arch-${{ github.event.inputs.architecture }}-debug-${{ github.event.inputs.debug }}
           path: target/libseda_tally_vm*.*
           overwrite: true

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -66,12 +66,12 @@ jobs:
           cargo xtask apt-install ${{ github.event.inputs.architecture }}
 
       - name: 🔨 Build Debug Library For ${{ github.event.inputs.architecture }}
-        if: ${{ github.event.inputs.debug }}
+        if: ${{ github.event.inputs.debug == 'true' }}
         run: |
           cargo xtask compile ${{ github.event.inputs.architecture }} --debug
       
       - name: 🔨 Build Library For ${{ github.event.inputs.architecture }}
-        if: ${{ !github.event.inputs.debug }}
+        if:  ${{ github.event.inputs.debug == 'false' }}
         run: |
           cargo xtask compile ${{ github.event.inputs.architecture }}
       

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -141,9 +141,9 @@ impl Compile {
             }
             Arch::StaticAarch64 => {
                 std::env::set_var("CC", "/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc");
-                "libseda_tally_vm.aarch64.static.a"
+                "libseda_tally_vm_muslc.aarch64.a"
             }
-            Arch::StaticX86_64 => "libseda_tally_vm.x86_64.static.a",
+            Arch::StaticX86_64 => "libseda_tally_vm_muslc.x86_64.a",
         };
 
         let path = if debug {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

https://github.com/sedaprotocol/seda-wasm-vm/actions/runs/9785035970

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- It fixes release mode builds; I had only tested debug builds and assumed the release one would work. My bad.
- Fixes some filename stuff. I realized before that for the nonstatic, I was renaming the `.so` extension to `.a.` There was no harm there, but it may have led to confusion.
- State in the artifact whether it's debugging or not for clarity, and the branch it came from.
- Add an all mode.
- renamed `cargo xtask ci-install` to `cargo xtask apt-install` since it works with `apt` in general. I tested this on wsl :).
- Fixes CI not respecting asking for release builds.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

CI running at the moment to test :).

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
