### PR TITLE
Fix: empty args causes panic

### DIFF
--- a/libtallyvm/src/lib.rs
+++ b/libtallyvm/src/lib.rs
@@ -206,7 +206,7 @@ mod test {
     use crate::_execute_tally_vm;
 
     #[test]
-    fn test_execute_tally_vm() {
+    fn execute_tally_vm() {
         let wasm_bytes = include_bytes!("../../debug.wasm");
         let result = _execute_tally_vm(
             wasm_bytes.to_vec(),
@@ -214,6 +214,16 @@ mod test {
             HashMap::default(),
         )
         .unwrap();
+
+        result.stdout.iter().for_each(|line| print!("{}", line));
+
+        dbg!(result);
+    }
+
+    #[test]
+    fn execute_tally_vm_no_args() {
+        let wasm_bytes = include_bytes!("../../tally.wasm");
+        let result = _execute_tally_vm(wasm_bytes.to_vec(), vec![], HashMap::default()).unwrap();
 
         result.stdout.iter().for_each(|line| print!("{}", line));
 

--- a/tallyvm/execute.go
+++ b/tallyvm/execute.go
@@ -38,10 +38,27 @@ func ExecuteTallyVm(bytes []byte, args []string, envs map[string]string) VmResul
 		i++
 	}
 
+	var bytesPtr *C.uint8_t
+	if len(bytes) > 0 {
+		bytesPtr = (*C.uint8_t)(unsafe.Pointer(&bytes[0]))
+	}
+
+	var argsPtr **C.char
+	if len(args) > 0 {
+		argsPtr = &argsC[0]
+	}
+
+	var keysPtr **C.char
+	var valuesPtr **C.char
+	if len(envs) > 0 {
+		keysPtr = &keys[0]
+		valuesPtr = &values[0]
+	}
+
 	result := C.execute_tally_vm(
-		(*C.uint8_t)(unsafe.Pointer(&bytes[0])), C.uintptr_t(len(bytes)),
-		(**C.char)(unsafe.Pointer(&argsC[0])), C.uintptr_t(len(args)),
-		(**C.char)(unsafe.Pointer(&keys[0])), (**C.char)(unsafe.Pointer(&values[0])), C.uintptr_t(len(envs)),
+		bytesPtr, C.uintptr_t(len(bytes)),
+		argsPtr, C.uintptr_t(len(args)),
+		keysPtr, valuesPtr, C.uintptr_t(len(envs)),
 	)
 	exitMessage := C.GoString(result.exit_info.exit_message)
 	exitCode := int(result.exit_info.exit_code)

--- a/tallyvm/execute_test.go
+++ b/tallyvm/execute_test.go
@@ -33,3 +33,24 @@ func TestTallyBinary(t *testing.T) {
 	fmt.Println(res)
 	t.Log(res)
 }
+
+func TestTallyBinaryNoArgs(t *testing.T) {
+	file := "../tally.wasm"
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := tallyvm.ExecuteTallyVm(data, []string{}, map[string]string{
+		"CONSENSUS": "true",
+		"VM_MODE":   "tally",
+	})
+
+	assert.Equal(t, "", res.ExitInfo.ExitMessage)
+	assert.Equal(t, 255, res.ExitInfo.ExitCode)
+	assert.Empty(t, res.Result)
+	assert.NotEmpty(t, res.Stderr)
+	assert.NotEmpty(t, res.Stdout)
+	fmt.Println(res)
+	t.Log(res)
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So go, and don't panic if no args(or bytes or env vars) are sent to the VM. 

Since the go side was the problem, we don't need to update the library files.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Made the pointers, then have the vars assigned if relevant. 

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Added a new test to confirm this on both the rust and go side.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #16
