### PR TITLE
fix(go): free config dir string

### DIFF
--- a/tallyvm/execute.go
+++ b/tallyvm/execute.go
@@ -27,6 +27,7 @@ var TallyMaxBytes uint
 func ExecuteTallyVm(bytes []byte, args []string, envs map[string]string) VmResult {
 	// convert config dir to C string
 	configDirC := C.CString(LogDir)
+	defer C.free(unsafe.Pointer(configDirC))
 
 	argsC := make([]*C.char, len(args))
 	for i, s := range args {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

To fix the memory leak on the golang side.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Free the constructed CString from the golang side.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

I started using Valgrind to test the memory.

Good news: from the golang side it looks like it's ok.

From the rust/c side: Less ok.
- There is 1 definitive leak, that I played around with a while a while I couldn't figure out how to fix.
- And 80 still reachable occurrences... which aren't a memory leak per say, but memory that would be reclaimed when the process ends.
  - So problem... since this is run by the chain that process never ends and therefore those add up... I think.
  - Some(most?) of these aren't from our own library, but I'm unsure if it's from us using a library incorrectly or the library we are using is at fault.

Valgrind summary of running a binary made from one of the golang tests:
```
HEAP SUMMARY:
==583458==     in use at exit: 4,644,074 bytes in 1,050 blocks
==583458==   total heap usage: 613,745 allocs, 612,695 frees, 298,702,689 bytes allocated
```

TLDR at least for that particular test binary the VM hoards ~4.5 million bytes of memory per execution.

We should verify these other leaks by sshing into a machine and running
`watch -n 5 'ps -o pid,comm,rss -p sedad-pid' and see if the RSS value increases.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
